### PR TITLE
Dockerfile: multistage docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM rust:alpine
-COPY . .
+# Build Stage
+FROM rust:alpine AS builder
+WORKDIR /usr/src/
 RUN apk add --no-cache libgcc musl-dev
-RUN cargo install --path .
-EXPOSE 8080
-EXPOSE 5000
-ENTRYPOINT ["/usr/local/cargo/bin/flotte-user-management"]
+RUN rustup target add x86_64-unknown-linux-musl
+
+RUN USER=root cargo new flotte-user-management
+WORKDIR /usr/src/flotte-user-management
+COPY Cargo.toml Cargo.lock ./
+
+COPY msg-rpc ./msg-rpc
+RUN cargo build --release
+COPY src ./src
+RUN cargo install --target x86_64-unknown-linux-musl --path .
+
+# Bundle Stage
+FROM scratch
+COPY --from=builder /usr/local/cargo/bin/flotte-user-management .
+
+ENTRYPOINT ["./flotte-user-management"]


### PR DESCRIPTION
Das Dockerimage ist so nur noch 8MB groß :). Natürlich ergibt es keinen Sinn, wenn man direkt auf dem Zielsystem docker build ausführt, weil ja für den build ein großes Dockerimage gebraucht wird. Für CI mit dockerhub oder so würde es aber Sinn ergeben